### PR TITLE
Can't use nunjucks syntax outside of mj-text

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,34 @@ or if you want to contribute see this READMEs:
 This project hasn't build-in authentication system, it's a internal service in your stack,
 you must protect it by a private network or [Basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) system.
 
+### How does the multi-language support works?
+
+Inside your mail templates folders, you can create multiple languages files for the same email, in the following format: `{lang}.(mjml|subject|txt)`.
+
+You also need to let a default file in case the language is not found or no language is requested.
+
+So, for example, your folder should look something like this:
+
+```
+$ ls mail-templates/mail-example
+default.mjml       default.subject             fr.txt            de.mjml           de.subject          es.txt
+default.txt        fr.mjml                     fr.subject        de.txt            es.mjml             es.subject
+```
+
+Then, you can add the `lang` property to the body of your request, which will send the email with the requested language if it exists.
+
+For example, the following body will try to send a german email:
+
+```
+{
+  "from": "no-reply@example.com",
+  "to": "john.doe@example.com",
+  "lang": "de"
+}
+```
+
+If the `lang` property is not present in the body of your request, the default email will be sent.
+
 ### Why « Gibbon-mail » name?
 
 [Gibbon](https://en.wikipedia.org/wiki/Gibbon) as an allusion to [Mandrill App](https://mandrill.com/).

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -111,15 +111,17 @@ function getSubject(templatePath, values) {
 }
 
 function getHtml(templatePath, values) {
-    return nunjucks.renderString(
-        mjml2html(fs.readFileSync(
-            templatePath,
-            {
-                encoding: 'utf8'
-            }
-        )).html,
-        values
-    );
+    return mjml2html(
+        nunjucks.renderString(
+            fs.readFileSync(
+                templatePath,
+                {
+                    encoding: 'utf8'
+                }
+            ),
+            values
+        )
+    ).html;
 }
 
 function replaceAllCIDByPreviewUrl(data, ctx) {

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -141,9 +141,9 @@ function getTxt(templatePath, values) {
 router.post('/v1/templates/:name/preview', (ctx) => {
     const templatePath = path.join(ctx.config.get('template_path'), ctx.params.name);
 
-    const subjectTemplatePath = path.join(templatePath, 'default.subject');
-    const mjmlTemplatePath = path.join(templatePath, 'default.mjml');
-    const txtTemplatePath = path.join(templatePath, 'default.txt');
+    const subjectTemplatePath = path.join(templatePath, `${ctx.request.body.lang || 'default'}.subject`);
+    const mjmlTemplatePath = path.join(templatePath, `${ctx.request.body.lang || 'default'}.mjml`);
+    const txtTemplatePath = path.join(templatePath, `${ctx.request.body.lang || 'default'}.txt`);
 
     const templates = [subjectTemplatePath, mjmlTemplatePath, txtTemplatePath];
     
@@ -173,14 +173,21 @@ router.post('/v1/templates/:name/send/:stmpSelected?', async (ctx) => {
         ctx.params.stmpSelected = 'smtp1';
     }
 
-    const subjectTemplatePath = path.join(templatePath, 'default.subject');
-    const mjmlTemplatePath = path.join(templatePath, 'default.mjml');
-    const txtTemplatePath = path.join(templatePath, 'default.txt');
+    let subjectTemplatePath = path.join(templatePath, `${ctx.request.body.lang || 'default'}.subject`);
+    let mjmlTemplatePath = path.join(templatePath, `${ctx.request.body.lang || 'default'}.mjml`);
+    let txtTemplatePath = path.join(templatePath, `${ctx.request.body.lang || 'default'}.txt`);
     const attachmentsPath = path.join(
         ctx.config.get('template_path'),
         ctx.params.name,
         'attachments'
     );
+
+    if (ctx.request.body.lang && (!fs.existsSync(subjectTemplatePath) || !fs.existsSync(mjmlTemplatePath) || !fs.existsSync(txtTemplatePath))) {
+        console.warn(`Can't find all "${ctx.request.body.lang}" files for this template, fallbacking to default language`);
+        subjectTemplatePath = path.join(templatePath, 'default.subject');
+        mjmlTemplatePath = path.join(templatePath, 'default.mjml');
+        txtTemplatePath = path.join(templatePath, 'default.txt');
+    }
 
     const templates = [subjectTemplatePath, mjmlTemplatePath, txtTemplatePath];
 

--- a/backend/src/swagger.yaml
+++ b/backend/src/swagger.yaml
@@ -89,6 +89,7 @@ paths:
                 to: "john.doe@example.com"
                 username: "john-doe"
                 is_new_user: "true"
+                lang: "en"
       responses:
         '200':
           description: Preview fields
@@ -133,6 +134,7 @@ paths:
                 to: "john.doe@example.com"
                 username: "john-doe"
                 is_new_user: "true"
+                lang: "en"
       responses:
         '200':
           content:

--- a/mail-templates/confirm_email/default.mjml
+++ b/mail-templates/confirm_email/default.mjml
@@ -23,13 +23,17 @@
 
         <mj-text>
           <p>This link will expire in 48 hours.</p>
+        </mj-text>
 
 {% if is_new_user %}
+        <mj-text>
           <p>If you did not sign up, you may simply ignore this email.</p>
-{% else %}
-          <p>If you did not make this request, you may simply ignore this email.</p>
-{% endif %}
         </mj-text>
+{% else %}
+        <mj-text>
+          <p>If you did not make this request, you may simply ignore this email.</p>
+        </mj-text>
+{% endif %}
       </mj-column>
     </mj-section>
   </mj-body>


### PR DESCRIPTION
# Context

We can't use nunjucks syntax outside of `mj-text` because mjml render before nunjucks